### PR TITLE
Add display_timezone support to dateTime element

### DIFF
--- a/packages/gatsby-source/src/schemaTemplates.ts
+++ b/packages/gatsby-source/src/schemaTemplates.ts
@@ -53,6 +53,7 @@ type __KONTENT_ITEM_DATE_TIME_ELEMENT__ {
   name: String!
   type: String!
   value: Date @dateformat
+  display_timezone: String
 }
 
 type __KONTENT_ITEM_ASSET_ELEMENT__ {

--- a/packages/gatsby-source/src/types.d.ts
+++ b/packages/gatsby-source/src/types.d.ts
@@ -37,6 +37,7 @@ interface KontentItemElement {
   images: { [key: string]: RichTextElementImage } | RichTextElementImage[];
   links: { [key: string]: RichTextElementLink } | RichTextElementLink[];
   modular_content: string[];
+  display_timezone?: string;
 }
 
 interface AssetElementValue {

--- a/packages/gatsby-source/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
+++ b/packages/gatsby-source/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
@@ -70,6 +70,7 @@ type kontent_item_date_time_element_value {
   name: String!
   type: String!
   value: Date @dateformat
+  display_timezone: String
 }
 
 type kontent_item_asset_element_value {

--- a/packages/gatsby-source/tests/__snapshots__/sourceNodes.items.spec.ts.snap
+++ b/packages/gatsby-source/tests/__snapshots__/sourceNodes.items.spec.ts.snap
@@ -483,6 +483,7 @@ Currently I am interested in Gatsby.js. I have released the third version of Gat
         "value": null,
       },
       "date_of_birth": Object {
+        "display_timezone": "Europe/Warsaw",
         "name": "Date of Birth",
         "type": "date_time",
         "value": "1991-07-24T00:00:00Z",
@@ -546,7 +547,7 @@ Currently I am interested in Gatsby.js. I have released the third version of Gat
     },
     "id": "dummyId-kontent_item_default_d72eea98-774f-48fc-b52a-7ebc51271855",
     "internal": Object {
-      "contentDigest": "9185dc537778af5d21f6a315b278bc13",
+      "contentDigest": "c5db71ff30695d3cebd3d30df7483648",
       "type": "kontent_item_person",
     },
     "preferred_language": "default",
@@ -1289,6 +1290,7 @@ GraphQL nodes of content items contain the ordinary \`system\` and \`elements\` 
         "value": "#1b058b",
       },
       "date_of_birth": Object {
+        "display_timezone": "Europe/Warsaw",
         "name": "Date of Birth",
         "type": "date_time",
         "value": "2020-03-19T00:00:00Z",
@@ -1341,7 +1343,7 @@ GraphQL nodes of content items contain the ordinary \`system\` and \`elements\` 
     },
     "id": "dummyId-kontent_item_Another_language_fbac9baf-441c-446e-a300-e31f171c26de",
     "internal": Object {
-      "contentDigest": "3f09258a316d1e073bd3ad284ee7349d",
+      "contentDigest": "2cc0f19864b1d3c08d190855f3dd3488",
       "type": "kontent_item_person",
     },
     "preferred_language": "Another_language",
@@ -1424,6 +1426,7 @@ Currently I am interested in Gatsby.js. I have released the third version of Gat
         "value": null,
       },
       "date_of_birth": Object {
+        "display_timezone": "Europe/Warsaw",
         "name": "Date of Birth",
         "type": "date_time",
         "value": "1991-07-24T00:00:00Z",
@@ -1476,7 +1479,7 @@ Currently I am interested in Gatsby.js. I have released the third version of Gat
     },
     "id": "dummyId-kontent_item_Another_language_d72eea98-774f-48fc-b52a-7ebc51271855",
     "internal": Object {
-      "contentDigest": "08de6110ee37e59a0f57cef3417eb7ad",
+      "contentDigest": "8075b6d655556337324e91604a1b036f",
       "type": "kontent_item_person",
     },
     "preferred_language": "Another_language",

--- a/packages/gatsby-source/tests/__snapshots__/sourceNodes.types.spec.ts.snap
+++ b/packages/gatsby-source/tests/__snapshots__/sourceNodes.types.spec.ts.snap
@@ -67,13 +67,14 @@ Array [
       },
       Object {
         "codename": "date_of_birth",
+        "display_timezone": "Europe/Warsaw",
         "name": "Date of Birth",
         "type": "date_time",
       },
     ],
     "id": "dummyId-kontent_type_person",
     "internal": Object {
-      "contentDigest": "358dfd89e48ae7c223d32a3943f343af",
+      "contentDigest": "a0653eafc4c6dc5fb5c0b8d5e54e079c",
       "type": "kontent_type",
     },
     "system": Object {

--- a/packages/gatsby-source/tests/__snapshots__/webhookProcessor.spec.ts.snap
+++ b/packages/gatsby-source/tests/__snapshots__/webhookProcessor.spec.ts.snap
@@ -333,6 +333,7 @@ Array [
 <p>Enjoy!</p>",
       },
       "date": Object {
+        "display_timezone": "Europe/Warsaw",
         "name": "Date",
         "type": "date_time",
         "value": "2020-07-31T00:00:00Z",
@@ -355,7 +356,7 @@ Array [
     },
     "id": "dummyId-kontent_item_en-US_5927f3d3-4fcb-4e2c-8d12-a2954339a87d",
     "internal": Object {
-      "contentDigest": "71f32c5c590359ba36456c011e34432b",
+      "contentDigest": "74f57c1c19b4949467e8c06606f52bfd",
       "type": "kontent_item_article",
     },
     "preferred_language": "en-US",

--- a/packages/gatsby-source/tests/complexContentItemsFirstLanguageFakeReponse.json
+++ b/packages/gatsby-source/tests/complexContentItemsFirstLanguageFakeReponse.json
@@ -335,7 +335,8 @@
         "date_of_birth": {
           "type": "date_time",
           "name": "Date of Birth",
-          "value": "1991-07-24T00:00:00Z"
+          "value": "1991-07-24T00:00:00Z",
+          "display_timezone": "Europe/Warsaw"
         },
         "profile_photo": {
           "type": "asset",

--- a/packages/gatsby-source/tests/complexContentItemsSecondLanguageFakeReponse.json
+++ b/packages/gatsby-source/tests/complexContentItemsSecondLanguageFakeReponse.json
@@ -331,7 +331,8 @@
         "date_of_birth": {
           "type": "date_time",
           "name": "Date of Birth",
-          "value": "2020-03-19T00:00:00Z"
+          "value": "2020-03-19T00:00:00Z",
+          "display_timezone": "Europe/Warsaw"
         },
         "profile_photo": {
           "type": "asset",
@@ -422,7 +423,8 @@
         "date_of_birth": {
           "type": "date_time",
           "name": "Date of Birth",
-          "value": "1991-07-24T00:00:00Z"
+          "value": "1991-07-24T00:00:00Z",
+          "display_timezone": "Europe/Warsaw"
         },
         "profile_photo": {
           "type": "asset",

--- a/packages/gatsby-source/tests/complexTypesFakeResponse.json
+++ b/packages/gatsby-source/tests/complexTypesFakeResponse.json
@@ -61,7 +61,8 @@
         },
         "date_of_birth": {
           "type": "date_time",
-          "name": "Date of Birth"
+          "name": "Date of Birth",
+          "display_timezone": "Europe/Warsaw"
         }
       }
     },

--- a/packages/gatsby-source/tests/webhookUsedByUnpublishedClientItemResponse.json
+++ b/packages/gatsby-source/tests/webhookUsedByUnpublishedClientItemResponse.json
@@ -33,7 +33,8 @@
       "date": {
         "type": "date_time",
         "name": "Date",
-        "value": "2020-07-31T00:00:00Z"
+        "value": "2020-07-31T00:00:00Z",
+        "display_timezone": "Europe/Warsaw"
       },
       "category": {
         "type": "modular_content",


### PR DESCRIPTION
### Motivation

A new feature was added on kontent-ai side - support for timezones (https://portal.productboard.com/kontent/2-kontent-ai-public-roadmap/c/176-configure-timezones-when-working-with-date-and-time-element). By default the "value" field contains the UTC time, but REST API now also stores a new field called "display_timezone", which should contain a timezone string.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added (updated snapshots)
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
